### PR TITLE
Update redirect to just use path

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -52,7 +52,7 @@ func streamFromStorageProvider(w http.ResponseWriter, r *http.Request, clients r
 	id := vars[routes.ResourceIdVarKey]
 	slug := vars[routes.SlugVarKey]
 
-	ix := getInteractive(w, r, id, clients, serviceAuthToken)
+	ix, url := getInteractive(w, r, id, clients, serviceAuthToken)
 	if ix == nil {
 		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("failed to find resource id %s", id))
 		return
@@ -60,7 +60,6 @@ func streamFromStorageProvider(w http.ResponseWriter, r *http.Request, clients r
 
 	// redirect if slug mismatch
 	if slug != "" && ix.Metadata != nil && ix.Metadata.HumanReadableSlug != slug {
-		url := fmt.Sprintf("/%s/%s-%s%s", routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
 		http.Redirect(w, r, url, http.StatusMovedPermanently)
 	}
 
@@ -96,7 +95,7 @@ func streamFromStorageProvider(w http.ResponseWriter, r *http.Request, clients r
 	}
 }
 
-func getInteractive(w http.ResponseWriter, r *http.Request, id string, clients routes.Clients, serviceAuthToken string) *interactives.Interactive {
+func getInteractive(w http.ResponseWriter, r *http.Request, id string, clients routes.Clients, serviceAuthToken string) (*interactives.Interactive, string) {
 	all, err := clients.API.ListInteractives(r.Context(), "", serviceAuthToken,
 		&interactives.QueryParams{
 			Offset: 0,
@@ -106,32 +105,32 @@ func getInteractive(w http.ResponseWriter, r *http.Request, id string, clients r
 	)
 	if err != nil {
 		setStatusCode(r, w, http.StatusInternalServerError, fmt.Errorf("failed to get from interactives api %w", err))
-		return nil
+		return nil, ""
 	}
 
 	if all.TotalCount != 1 {
 		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("cannot find interactive %w", err))
-		return nil
+		return nil, ""
 	}
 
 	// block access if interactive is unpublished
 	if !*(all.Items[0].Published) {
 		setStatusCode(r, w, http.StatusNotFound, errors.New("access prohibited for unpublished interactives"))
-		return nil
+		return nil, ""
 	}
-	return &all.Items[0]
+
+	first := &all.Items[0]
+	return first, fmt.Sprintf("/%s/%s-%s%s", routes.ResourceTypeKey, first.Metadata.HumanReadableSlug, first.Metadata.ResourceID, routes.EmbeddedSuffix)
+
 }
 
 func redirectToFullyQualifiedURL(w http.ResponseWriter, r *http.Request, clients routes.Clients, serviceAuthToken string) {
 	vars := mux.Vars(r)
 	id := vars[routes.ResourceIdVarKey]
-	url := ""
-
-	if ix := getInteractive(w, r, id, clients, serviceAuthToken); ix == nil {
+	ix, url := getInteractive(w, r, id, clients, serviceAuthToken)
+	if ix == nil {
 		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("failed to find resource id %s", id))
 		return
-	} else {
-		url = fmt.Sprintf("/%s/%s-%s%s", routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
 	}
 
 	http.Redirect(w, r, url, http.StatusMovedPermanently)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -60,7 +60,12 @@ func streamFromStorageProvider(w http.ResponseWriter, r *http.Request, clients r
 
 	// redirect if slug mismatch
 	if slug != "" && ix.Metadata != nil && ix.Metadata.HumanReadableSlug != slug {
-		url := fmt.Sprintf("http://%s/%s/%s-%s%s", r.Host, routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
+		//https://github.com/golang/go/issues/28940
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		url := fmt.Sprintf("%s://%s/%s/%s-%s%s", scheme, r.Host, routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
 		http.Redirect(w, r, url, http.StatusMovedPermanently)
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -131,7 +131,7 @@ func redirectToFullyQualifiedURL(w http.ResponseWriter, r *http.Request, clients
 		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("failed to find resource id %s", id))
 		return
 	} else {
-		url = fmt.Sprintf("http://%s/%s/%s-%s%s", r.Host, routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
+		url = fmt.Sprintf("/%s/%s-%s%s", routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
 	}
 
 	http.Redirect(w, r, url, http.StatusMovedPermanently)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -60,12 +60,7 @@ func streamFromStorageProvider(w http.ResponseWriter, r *http.Request, clients r
 
 	// redirect if slug mismatch
 	if slug != "" && ix.Metadata != nil && ix.Metadata.HumanReadableSlug != slug {
-		//https://github.com/golang/go/issues/28940
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		url := fmt.Sprintf("%s://%s/%s/%s-%s%s", scheme, r.Host, routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
+		url := fmt.Sprintf("/%s/%s-%s%s", routes.ResourceTypeKey, ix.Metadata.HumanReadableSlug, ix.Metadata.ResourceID, routes.EmbeddedSuffix)
 		http.Redirect(w, r, url, http.StatusMovedPermanently)
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -102,7 +102,7 @@ func TestInteractives(t *testing.T) {
 					ListInteractivesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, q *interactives.QueryParams) (interactives.List, error) {
 						return interactives.List{
 							Items: []interactives.Interactive{
-								{ID: "123456", Published: &pub, Metadata: nil, Archive: nil},
+								getTestInteractive(pub, nil),
 							},
 							Count:      1,
 							Offset:     0,
@@ -142,7 +142,7 @@ func TestInteractives(t *testing.T) {
 				ListInteractivesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, q *interactives.QueryParams) (interactives.List, error) {
 					return interactives.List{
 						Items: []interactives.Interactive{
-							{ID: "123456", Published: &pub, Metadata: nil, Archive: nil},
+							getTestInteractive(pub, nil),
 						},
 						Count:      1,
 						Offset:     0,
@@ -177,7 +177,7 @@ func TestInteractives(t *testing.T) {
 				ListInteractivesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, q *interactives.QueryParams) (interactives.List, error) {
 					return interactives.List{
 						Items: []interactives.Interactive{
-							{ID: "123456", Published: &pub, Metadata: mData, Archive: nil},
+							getTestInteractive(pub, mData),
 						},
 						Count:      1,
 						Offset:     0,
@@ -216,7 +216,7 @@ func TestInteractives(t *testing.T) {
 				ListInteractivesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, q *interactives.QueryParams) (interactives.List, error) {
 					return interactives.List{
 						Items: []interactives.Interactive{
-							{ID: "123456", Published: &pub, Metadata: mData, Archive: nil},
+							getTestInteractive(pub, mData),
 						},
 						Count:      1,
 						Offset:     0,
@@ -249,4 +249,19 @@ func TestInteractives(t *testing.T) {
 			})
 		})
 	})
+}
+
+func getTestInteractive(published bool, m *interactives.InteractiveMetadata) interactives.Interactive {
+	if m == nil {
+		m = &interactives.InteractiveMetadata{
+			HumanReadableSlug: "slug",
+			ResourceID:        "abcd123e",
+		}
+	}
+	return interactives.Interactive{
+		ID:        "123456",
+		Published: &published,
+		Metadata:  m,
+		Archive:   nil,
+	}
 }


### PR DESCRIPTION
### What

Fixes hardcoded scheme in redirect URL. ONS is secure (and redirects non requests with a 307) so reasonable to assume requests will be on `https`. 

Looks like redirects dont need full scheme and host - just path: https://pkg.go.dev/net/http#Redirect

### How to review

Eyeball enough I think.

### Who can review

Anyone
