### PR TITLE
Move logic to block access to an interactive to API

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -110,12 +109,6 @@ func getInteractive(w http.ResponseWriter, r *http.Request, id string, clients r
 
 	if all.TotalCount != 1 {
 		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("cannot find interactive %w", err))
-		return nil, ""
-	}
-
-	// block access if interactive is unpublished
-	if !*(all.Items[0].Published) {
-		setStatusCode(r, w, http.StatusNotFound, errors.New("access prohibited for unpublished interactives"))
 		return nil, ""
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -136,40 +136,6 @@ func TestInteractives(t *testing.T) {
 
 		})
 
-		Convey("Request to an unpublished interactive is made", func() {
-			pub := false
-			apiMock := &mocks_routes.InteractivesAPIClientMock{
-				ListInteractivesFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, q *interactives.QueryParams) (interactives.List, error) {
-					return interactives.List{
-						Items: []interactives.Interactive{
-							getTestInteractive(pub, nil),
-						},
-						Count:      1,
-						Offset:     0,
-						Limit:      10,
-						TotalCount: 1,
-					}, nil
-				},
-			}
-
-			clients := routes.Clients{
-				Storage: storageProvider,
-				API:     apiMock,
-			}
-
-			handler := Interactives(&config.Config{}, clients)
-
-			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			w := httptest.NewRecorder()
-			handler(w, req)
-
-			Convey("then the status code is 404", func() {
-				res := w.Result()
-				defer res.Body.Close()
-				So(res.StatusCode, ShouldEqual, http.StatusNotFound)
-			})
-		})
-
 		Convey("url with only resource-id must redirect", func() {
 			pub := true
 			mData := &interactives.InteractiveMetadata{HumanReadableSlug: "a-slug", ResourceID: "resid123"}


### PR DESCRIPTION
### What

Moving this logic to the dp-interactives-api. The API has a flag to determine mode, i.e. publishing or web - can use this on the GET/LIST endpoint to only return published interactives.

This means valid access from a www or API entrypoint.

### How to review

Just eyeball and check tests.

### Who can review

Anyone
