### PR TITLE
Add index.html to URLs with trailing slash

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -108,6 +109,10 @@ func findFile(filename string, ix *interactives.Interactive) (string, error) {
 		filename = RootFile
 	}
 
+	if strings.HasSuffix(filename, "/") {
+		filename = filename + RootFile
+	}
+
 	if ix.Archive != nil {
 		for _, f := range ix.Archive.Files {
 			if f.URI == filename {
@@ -124,12 +129,12 @@ func getInteractive(w http.ResponseWriter, r *http.Request, id string, clients r
 		&interactives.InteractiveFilter{Metadata: &interactives.InteractiveMetadata{ResourceID: id}},
 	)
 	if err != nil {
-		setStatusCode(r, w, http.StatusInternalServerError, fmt.Errorf("failed to get from interactives api %w", err))
+		setStatusCode(r, w, http.StatusInternalServerError, fmt.Errorf("failed to get from interactives api %s %w", id, err))
 		return nil, ""
 	}
 
 	if len(all) != 1 {
-		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("cannot find interactive %w", err))
+		setStatusCode(r, w, http.StatusNotFound, fmt.Errorf("cannot find interactive %s", id))
 		return nil, ""
 	}
 


### PR DESCRIPTION
render URLs like: `http://localhost:27300/interactives/label-Jj5hQkXP/E06000001/` with `index.html` at end - treat like filesystem would do.